### PR TITLE
Wire service to views and render first real briefing

### DIFF
--- a/CurrentState/Sources/App/AppState.swift
+++ b/CurrentState/Sources/App/AppState.swift
@@ -5,8 +5,9 @@ final class AppState: ObservableObject {
     @Published var messages: [Message] = []
     @Published var streamingState: StreamingState = .idle
     @Published var currentSessionId: String?
+    @Published var scrollTrigger = UUID()
 
-    private let claudeService = ClaudeCodeService()
+    private let claudeService: any ClaudeCodeServiceProtocol
     private let sessionStore = SessionStore()
     private var currentTask: Task<Void, Never>?
 
@@ -17,9 +18,15 @@ final class AppState: ObservableObject {
         case error(String) // something went wrong
     }
 
-    init() {
-        // Auto-generate briefing on launch
-        startNewBriefing()
+    init(claudeService: any ClaudeCodeServiceProtocol = ClaudeCodeService()) {
+        self.claudeService = claudeService
+    }
+
+    var errorMessage: String? {
+        if case .error(let message) = streamingState {
+            return message
+        }
+        return nil
     }
 
     func startNewBriefing() {
@@ -64,6 +71,7 @@ final class AppState: ObservableObject {
                         streamingState = .streaming
                     }
                     messages[messageIndex].content += text
+                    scrollTrigger = UUID()
 
                 case .result(let resultEvent):
                     currentSessionId = resultEvent.sessionId

--- a/CurrentState/Sources/Services/ClaudeCodeService.swift
+++ b/CurrentState/Sources/Services/ClaudeCodeService.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Manages Claude Code subprocess lifecycle and streams parsed events.
-final class ClaudeCodeService: Sendable {
+final class ClaudeCodeService: ClaudeCodeServiceProtocol {
 
     /// Stream events from a Claude Code subprocess.
     ///

--- a/CurrentState/Sources/Services/ClaudeCodeServiceProtocol.swift
+++ b/CurrentState/Sources/Services/ClaudeCodeServiceProtocol.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol ClaudeCodeServiceProtocol: Sendable {
+    func stream(prompt: String, sessionId: String?) -> AsyncThrowingStream<StreamEvent, Error>
+}

--- a/CurrentState/Sources/Views/MainView.swift
+++ b/CurrentState/Sources/Views/MainView.swift
@@ -19,6 +19,13 @@ struct MainView: View {
                                 .id(message.id)
                         }
 
+                        // Error banner
+                        if let errorMessage = appState.errorMessage {
+                            ErrorBanner(message: errorMessage) {
+                                appState.startNewBriefing()
+                            }
+                        }
+
                         // Loading indicator
                         if appState.streamingState == .loading {
                             LoadingIndicator()
@@ -27,7 +34,7 @@ struct MainView: View {
                     }
                     .padding()
                 }
-                .onChange(of: appState.messages.count) {
+                .onChange(of: appState.scrollTrigger) {
                     if let last = appState.messages.last {
                         withAnimation {
                             proxy.scrollTo(last.id, anchor: .bottom)
@@ -45,6 +52,12 @@ struct MainView: View {
             .disabled(appState.streamingState == .loading || appState.streamingState == .streaming)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .task {
+            guard ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil else { return }
+            if appState.messages.isEmpty && appState.streamingState == .idle {
+                appState.startNewBriefing()
+            }
+        }
     }
 
     private var header: some View {
@@ -65,6 +78,31 @@ struct MainView: View {
         }
         .padding(.horizontal)
         .padding(.vertical, 8)
+    }
+}
+
+struct ErrorBanner: View {
+    let message: String
+    let onRetry: () -> Void
+
+    var body: some View {
+        HStack {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+
+            Text(message)
+                .font(.subheadline)
+                .lineLimit(3)
+
+            Spacer()
+
+            Button("Retry") {
+                onRetry()
+            }
+            .buttonStyle(.bordered)
+        }
+        .padding()
+        .background(.red.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
     }
 }
 

--- a/CurrentState/Sources/Views/StatusIndicator.swift
+++ b/CurrentState/Sources/Views/StatusIndicator.swift
@@ -26,10 +26,12 @@ struct StatusIndicator: View {
 
     private var label: String {
         switch state {
-        case .idle: "Ready"
-        case .loading: "Working..."
-        case .streaming: "Streaming"
-        case .error: "Error"
+        case .idle: return "Ready"
+        case .loading: return "Working..."
+        case .streaming: return "Streaming"
+        case .error(let message):
+            let truncated = message.prefix(30)
+            return truncated.count < message.count ? "\(truncated)…" : message
         }
     }
 }

--- a/CurrentState/Tests/AppStateTests.swift
+++ b/CurrentState/Tests/AppStateTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import Current_State
+
+@MainActor
+final class AppStateTests: XCTestCase {
+
+    // MARK: - Init Safety
+
+    func testInitDoesNotAutoStart() {
+        let mock = MockClaudeCodeService()
+        _ = AppState(claudeService: mock)
+
+        XCTAssertEqual(mock.callCount, 0, "AppState.init() must not call the service")
+    }
+
+    // MARK: - Briefing Flow
+
+    func testStartNewBriefingSendsCorrectPrompt() async {
+        let mock = MockClaudeCodeService()
+        mock.eventsToReturn = [
+            .init_(.init(sessionId: "session-1", model: "claude-opus-4-6")),
+            .assistantText("Hello"),
+            .result(.init(sessionId: "session-1", fullText: "Hello", isError: false, durationMs: 100, costUsd: 0.01)),
+        ]
+
+        let appState = AppState(claudeService: mock)
+        appState.startNewBriefing()
+
+        // Wait for the internal Task to complete
+        await Task.yield()
+        // Give the runloop a moment to process
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(mock.callCount, 1)
+        XCTAssertEqual(mock.lastPrompt, "/currentstate")
+        XCTAssertNil(mock.lastSessionId, "First briefing should not pass a session ID")
+        XCTAssertEqual(appState.currentSessionId, "session-1")
+        XCTAssertEqual(appState.streamingState, .idle)
+
+        // Should have one assistant message with accumulated text
+        let assistantMessages = appState.messages.filter { $0.role == .assistant }
+        XCTAssertEqual(assistantMessages.count, 1)
+        XCTAssertEqual(assistantMessages.first?.content, "Hello")
+    }
+
+    // MARK: - Error Handling
+
+    func testStreamingErrorSetsErrorState() async {
+        let mock = MockClaudeCodeService()
+        mock.errorToThrow = ClaudeCodeError.binaryNotFound
+
+        let appState = AppState(claudeService: mock)
+        appState.startNewBriefing()
+
+        await Task.yield()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        if case .error(let message) = appState.streamingState {
+            XCTAssertTrue(message.contains("Claude Code CLI not found"), "Error message should mention CLI not found, got: \(message)")
+        } else {
+            XCTFail("Expected error state, got \(appState.streamingState)")
+        }
+    }
+
+    // MARK: - Scroll Trigger
+
+    func testScrollTriggerUpdatesOnStreamingText() async {
+        let mock = MockClaudeCodeService()
+        mock.eventsToReturn = [
+            .init_(.init(sessionId: "s1", model: "m")),
+            .assistantText("chunk1"),
+            .assistantText("chunk2"),
+            .result(.init(sessionId: "s1", fullText: "chunk1chunk2", isError: false, durationMs: nil, costUsd: nil)),
+        ]
+
+        let appState = AppState(claudeService: mock)
+        let initialTrigger = appState.scrollTrigger
+
+        appState.startNewBriefing()
+
+        await Task.yield()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertNotEqual(appState.scrollTrigger, initialTrigger, "scrollTrigger should change after streaming text")
+    }
+
+    // MARK: - Error Message Computed Property
+
+    func testErrorMessageComputedProperty() {
+        let mock = MockClaudeCodeService()
+        let appState = AppState(claudeService: mock)
+
+        // Idle state → nil
+        XCTAssertNil(appState.errorMessage)
+
+        // Error state → extracts message
+        appState.streamingState = .error("Something went wrong")
+        XCTAssertEqual(appState.errorMessage, "Something went wrong")
+
+        // Back to idle → nil again
+        appState.streamingState = .idle
+        XCTAssertNil(appState.errorMessage)
+    }
+}

--- a/CurrentState/Tests/MockClaudeCodeService.swift
+++ b/CurrentState/Tests/MockClaudeCodeService.swift
@@ -1,0 +1,32 @@
+import Foundation
+@testable import Current_State
+
+/// Test mock that returns preconfigured events without spawning any subprocess.
+final class MockClaudeCodeService: ClaudeCodeServiceProtocol, @unchecked Sendable {
+    var eventsToReturn: [StreamEvent] = []
+    var errorToThrow: Error?
+
+    private(set) var callCount = 0
+    private(set) var lastPrompt: String?
+    private(set) var lastSessionId: String?
+
+    func stream(prompt: String, sessionId: String?) -> AsyncThrowingStream<StreamEvent, Error> {
+        callCount += 1
+        lastPrompt = prompt
+        lastSessionId = sessionId
+
+        let events = eventsToReturn
+        let error = errorToThrow
+
+        return AsyncThrowingStream { continuation in
+            if let error {
+                continuation.finish(throwing: error)
+                return
+            }
+            for event in events {
+                continuation.yield(event)
+            }
+            continuation.finish()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ClaudeCodeServiceProtocol` for dependency injection and testability
- Move briefing auto-start to MainView `.task` with XCTest environment guard
- Replace scroll observer with `scrollTrigger` UUID for reliable auto-scroll during streaming
- Add `ErrorBanner` view with inline error message and retry button
- Add `MockClaudeCodeService` and 5 AppState tests

## Test plan
- [x] `xcodebuild build` — zero errors
- [x] `xcodebuild test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)